### PR TITLE
合計得点でソートできるように #7

### DIFF
--- a/ui/display_window/display_window.gd
+++ b/ui/display_window/display_window.gd
@@ -8,5 +8,28 @@ func _ready() -> void:
 func update_element() -> void:
 	(get_node("%EventName") as Label).text = DataManager.event_name
 	
+	var sort_total_score: Array = []
+	
 	for i in range(7):
-		(get_node("%TotalScore/%Class" + str(i + 1)) as Label).text = str(DataManager.total_score[i]) + "点"
+		sort_total_score.append([DataManager.total_score[i], i])
+	
+	sort_total_score.sort_custom(
+		func(a, b) -> bool:
+			if a[0] > b[0]:
+				return true
+			elif a[0] < b[0]:
+				return false
+			else:
+				if a[1] < b[1]:
+					return true
+				else:
+					return false
+	)
+	
+	for i in range(7):
+		var score: int = sort_total_score[i][0]
+		var class_num: int = sort_total_score[i][1]
+		var score_label: ScoreLabel = (get_node("%TotalScore/%Class" + str(class_num + 1)) as ScoreLabel)
+		
+		score_label.get_parent().move_child(score_label, i)
+		score_label.score.text = str(DataManager.total_score[class_num]) + "点"

--- a/ui/font/NotoSansJP-VariableFont_wght.ttf.import
+++ b/ui/font/NotoSansJP-VariableFont_wght.ttf.import
@@ -15,7 +15,7 @@ dest_files=["res://.godot/imported/NotoSansJP-VariableFont_wght.ttf-41a9466e0f5b
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
-multichannel_signed_distance_field=true
+multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48
 allow_system_fallback=true
@@ -27,7 +27,12 @@ Fallbacks=null
 fallbacks=[]
 Compress=null
 compress=true
-preload=[]
+preload=[{
+"chars": [],
+"glyphs": [],
+"name": "New Configuration",
+"size": Vector2i(16, 0)
+}]
 language_support={}
 script_support={}
 opentype_features={}

--- a/ui/score_label/score_label.gd
+++ b/ui/score_label/score_label.gd
@@ -1,0 +1,5 @@
+extends HBoxContainer
+class_name ScoreLabel
+
+@onready var team_name: Label = get_node("TeamName")
+@onready var score: Label = get_node("Score")

--- a/ui/score_label/score_label.tscn
+++ b/ui/score_label/score_label.tscn
@@ -1,0 +1,16 @@
+[gd_scene load_steps=2 format=3 uid="uid://dwx2mr8nfla3"]
+
+[ext_resource type="Script" path="res://ui/score_label/score_label.gd" id="1_ku8t7"]
+
+[node name="ScoreLabel" type="HBoxContainer"]
+theme_override_constants/separation = 100
+script = ExtResource("1_ku8t7")
+
+[node name="TeamName" type="Label" parent="."]
+layout_mode = 2
+
+[node name="Score" type="Label" parent="."]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "0点"
+horizontal_alignment = 2

--- a/ui/total_score/total_score.tscn
+++ b/ui/total_score/total_score.tscn
@@ -1,99 +1,77 @@
-[gd_scene format=3 uid="uid://bogfygmnyaako"]
+[gd_scene load_steps=2 format=3 uid="uid://bogfygmnyaako"]
+
+[ext_resource type="PackedScene" uid="uid://dwx2mr8nfla3" path="res://ui/score_label/score_label.tscn" id="1_ylrda"]
 
 [node name="TotalScore" type="Control"]
 layout_mode = 3
 anchors_preset = 0
 
-[node name="GridContainer" type="GridContainer" parent="."]
-custom_minimum_size = Vector2(333, 0)
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 1
 anchors_preset = 6
 anchor_left = 1.0
 anchor_top = 0.5
 anchor_right = 1.0
 anchor_bottom = 0.5
-offset_left = -333.0
-offset_top = -377.0
-offset_bottom = 377.0
+offset_left = -40.0
+offset_top = -20.0
+offset_bottom = 20.0
 grow_horizontal = 0
 grow_vertical = 2
-theme_override_constants/h_separation = 16
-theme_override_constants/v_separation = 16
-columns = 2
 
-[node name="Label1" type="Label" parent="GridContainer"]
+[node name="Class1" parent="VBoxContainer" instance=ExtResource("1_ylrda")]
+unique_name_in_owner = true
 layout_mode = 2
+
+[node name="TeamName" parent="VBoxContainer/Class1" index="0"]
 text = "1組"
 
-[node name="Class1" type="Label" parent="GridContainer"]
+[node name="Class2" parent="VBoxContainer" instance=ExtResource("1_ylrda")]
 unique_name_in_owner = true
 layout_mode = 2
-size_flags_horizontal = 3
-text = "0点"
-horizontal_alignment = 2
 
-[node name="Label2" type="Label" parent="GridContainer"]
-layout_mode = 2
+[node name="TeamName" parent="VBoxContainer/Class2" index="0"]
 text = "2組"
 
-[node name="Class2" type="Label" parent="GridContainer"]
+[node name="Class3" parent="VBoxContainer" instance=ExtResource("1_ylrda")]
 unique_name_in_owner = true
 layout_mode = 2
-size_flags_horizontal = 3
-text = "0点"
-horizontal_alignment = 2
 
-[node name="Label3" type="Label" parent="GridContainer"]
-layout_mode = 2
+[node name="TeamName" parent="VBoxContainer/Class3" index="0"]
 text = "3組"
 
-[node name="Class3" type="Label" parent="GridContainer"]
+[node name="Class4" parent="VBoxContainer" instance=ExtResource("1_ylrda")]
 unique_name_in_owner = true
 layout_mode = 2
-size_flags_horizontal = 3
-text = "0点"
-horizontal_alignment = 2
 
-[node name="Label4" type="Label" parent="GridContainer"]
-layout_mode = 2
+[node name="TeamName" parent="VBoxContainer/Class4" index="0"]
 text = "4組"
 
-[node name="Class4" type="Label" parent="GridContainer"]
+[node name="Class5" parent="VBoxContainer" instance=ExtResource("1_ylrda")]
 unique_name_in_owner = true
 layout_mode = 2
-size_flags_horizontal = 3
-text = "0点"
-horizontal_alignment = 2
 
-[node name="Label5" type="Label" parent="GridContainer"]
-layout_mode = 2
+[node name="TeamName" parent="VBoxContainer/Class5" index="0"]
 text = "5組"
 
-[node name="Class5" type="Label" parent="GridContainer"]
+[node name="Class6" parent="VBoxContainer" instance=ExtResource("1_ylrda")]
 unique_name_in_owner = true
 layout_mode = 2
-size_flags_horizontal = 3
-text = "0点"
-horizontal_alignment = 2
 
-[node name="Label6" type="Label" parent="GridContainer"]
-layout_mode = 2
+[node name="TeamName" parent="VBoxContainer/Class6" index="0"]
 text = "6組"
 
-[node name="Class6" type="Label" parent="GridContainer"]
+[node name="Class7" parent="VBoxContainer" instance=ExtResource("1_ylrda")]
 unique_name_in_owner = true
 layout_mode = 2
-size_flags_horizontal = 3
-text = "0点"
-horizontal_alignment = 2
 
-[node name="Label7" type="Label" parent="GridContainer"]
-layout_mode = 2
+[node name="TeamName" parent="VBoxContainer/Class7" index="0"]
 text = "7組"
 
-[node name="Class7" type="Label" parent="GridContainer"]
-unique_name_in_owner = true
-layout_mode = 2
-size_flags_horizontal = 3
-text = "0点"
-horizontal_alignment = 2
+[editable path="VBoxContainer/Class1"]
+[editable path="VBoxContainer/Class2"]
+[editable path="VBoxContainer/Class3"]
+[editable path="VBoxContainer/Class4"]
+[editable path="VBoxContainer/Class5"]
+[editable path="VBoxContainer/Class6"]
+[editable path="VBoxContainer/Class7"]


### PR DESCRIPTION
合計得点の表示の構造をちょっと変更して並びかえがある程度簡単にできるようにした。その過程で、各組の得点の表示はScoreLabelというシーンにまとめた。この実装ではアニメーションには対応できないから、それが必要となるならこれは崩さなきゃいけなくなる。