### PR TITLE
ウィンドウのサイズを調節、フォントがブレないように #11

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="StreamingTool"
 run/main_scene="res://ui/display_window/display_window.tscn"
-config/features=PackedStringArray("4.2")
+config/features=PackedStringArray("4.4")
 config/icon="res://icon.png"
 
 [autoload]
@@ -25,12 +25,13 @@ window/size/viewport_width=1920
 window/size/viewport_height=1080
 window/size/transparent=true
 window/subwindows/embed_subwindows=false
-window/stretch/mode="canvas_items"
+window/stretch/mode="viewport"
 window/per_pixel_transparency/allowed=true
 
 [gui]
 
 theme/custom="res://ui/theme/main_theme.tres"
+theme/default_font_multichannel_signed_distance_field=true
 
 [rendering]
 

--- a/ui/display_window/display_window.gd
+++ b/ui/display_window/display_window.gd
@@ -1,4 +1,4 @@
-extends Control
+extends Node
 
 
 func _ready() -> void:

--- a/ui/display_window/display_window.tscn
+++ b/ui/display_window/display_window.tscn
@@ -4,27 +4,28 @@
 [ext_resource type="Script" path="res://ui/display_window/display_window.gd" id="1_q86rp"]
 [ext_resource type="PackedScene" uid="uid://n2i0p4ukf4c5" path="res://ui/operation_window/operation_window.tscn" id="1_ym0wc"]
 
-[node name="DisplayWindow" type="Control"]
-layout_mode = 3
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
+[node name="DisplayWindow" type="Node"]
 script = ExtResource("1_q86rp")
 
-[node name="EventName" type="Label" parent="."]
+[node name="Control" type="Control" parent="."]
+layout_mode = 3
+anchors_preset = 0
+offset_right = 40.0
+offset_bottom = 40.0
+
+[node name="EventName" type="Label" parent="Control"]
 unique_name_in_owner = true
 layout_mode = 1
 anchors_preset = 2
 anchor_top = 1.0
 anchor_bottom = 1.0
-offset_top = -94.0
-offset_right = 1.0
+offset_top = 946.0
+offset_right = 704.0
+offset_bottom = 1040.0
 grow_vertical = 0
 text = "ここに競技名が入ります"
 
-[node name="TotalScore" parent="." instance=ExtResource("1_kdvjr")]
+[node name="TotalScore" parent="Control" instance=ExtResource("1_kdvjr")]
 unique_name_in_owner = true
 layout_mode = 1
 anchors_preset = 6
@@ -32,15 +33,15 @@ anchor_left = 1.0
 anchor_top = 0.5
 anchor_right = 1.0
 anchor_bottom = 0.5
+offset_left = 1880.0
+offset_top = 520.0
+offset_right = 1880.0
+offset_bottom = 520.0
 grow_horizontal = 0
 grow_vertical = 2
 
 [node name="Window" type="Window" parent="."]
 initial_position = 1
 size = Vector2i(960, 540)
-always_on_top = true
-content_scale_size = Vector2i(1920, 1080)
-content_scale_mode = 1
-content_scale_aspect = 4
 
 [node name="OperationWindow" parent="Window" instance=ExtResource("1_ym0wc")]

--- a/ui/font/NotoSansJP-VariableFont_wght.ttf.import
+++ b/ui/font/NotoSansJP-VariableFont_wght.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/NotoSansJP-VariableFont_wght.ttf-41a9466e0f5b
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48
@@ -31,7 +32,8 @@ preload=[{
 "chars": [],
 "glyphs": [],
 "name": "New Configuration",
-"size": Vector2i(16, 0)
+&"size": Vector2i(32, 0),
+&"variation_embolden": 0.0
 }]
 language_support={}
 script_support={}

--- a/ui/operation_window/operation_window.tscn
+++ b/ui/operation_window/operation_window.tscn
@@ -31,8 +31,8 @@ text = "競技名"
 [node name="Event" type="OptionButton" parent="VBoxContainer/PanelContainer2/EventContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-item_count = 10
 selected = 0
+item_count = 10
 popup/item_0/text = "中一　水風船騎馬"
 popup/item_0/id = 0
 popup/item_1/text = "中二　酔いどれ親父をつかまえて"

--- a/ui/theme/operation_theme.tres
+++ b/ui/theme/operation_theme.tres
@@ -22,7 +22,7 @@ variation_opentype = {
 
 [resource]
 default_font = SubResource("FontVariation_v56nv")
-default_font_size = 32
+default_font_size = 16
 GridContainer/constants/h_separation = 64
 GridContainer/constants/v_separation = 8
 HBoxContainer/constants/separation = 64


### PR DESCRIPTION
ストレッチモードをviewportにすることで、描画ウィンドウをリサイズしたときに文字がおかしなことにならないようにした。ドロップダウンメニューが隠れてしまうので、操作ウィンドウを常に最全面表示しないようにした。